### PR TITLE
feat(dvc): add ground truth labels for one sequence in engie

### DIFF
--- a/data/raw/.gitignore
+++ b/data/raw/.gitignore
@@ -10,3 +10,4 @@
 /pyronear-platform/sequences
 /pyronear-platform-annotated-sequences
 /wildfire_temporal_test_selection
+/labelstudio

--- a/data/raw/pyronear-platform-annotated-sequences.dvc
+++ b/data/raw/pyronear-platform-annotated-sequences.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 3fc0e1d726646763d14f20b5c2ed0dac.dir
-  size: 1483240395
-  nfiles: 15217
+- md5: 002d2b35967962bd0a66b9af60b3a67c.dir
+  size: 1483240963
+  nfiles: 15225
   hash: md5
   path: pyronear-platform-annotated-sequences

--- a/data/raw/pyronear-platform-annotated-sequences.dvc
+++ b/data/raw/pyronear-platform-annotated-sequences.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 002d2b35967962bd0a66b9af60b3a67c.dir
-  size: 1483240963
-  nfiles: 15225
+- md5: 408084518978464702691cf4b43df125.dir
+  size: 1483246773
+  nfiles: 15307
   hash: md5
   path: pyronear-platform-annotated-sequences

--- a/data/raw/pyronear-platform-annotated-sequences.dvc
+++ b/data/raw/pyronear-platform-annotated-sequences.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 408084518978464702691cf4b43df125.dir
-  size: 1483246773
-  nfiles: 15307
+- md5: e9cb84ab57ea8159a2c7106565c5c68f.dir
+  size: 1483247254
+  nfiles: 15313
   hash: md5
   path: pyronear-platform-annotated-sequences

--- a/dvc.lock
+++ b/dvc.lock
@@ -434,9 +434,9 @@ stages:
     deps:
     - path: ./data/raw/pyronear-platform-annotated-sequences/
       hash: md5
-      md5: 002d2b35967962bd0a66b9af60b3a67c.dir
-      size: 1483240963
-      nfiles: 15225
+      md5: 408084518978464702691cf4b43df125.dir
+      size: 1483246773
+      nfiles: 15307
     - path: ./scripts/platform_train_loop/select_detections.py
       hash: md5
       md5: af4f940bf6cff0f1aa338a214cc59522
@@ -444,9 +444,9 @@ stages:
     outs:
     - path: ./data/interim/pyronear-platform/sequences/
       hash: md5
-      md5: 961ad9763f7d21524af120ca6a5876a7.dir
-      size: 478430836
-      nfiles: 4947
+      md5: 41f12ac46242b9580dd08082c0afb5ea.dir
+      size: 478432851
+      nfiles: 4973
   split_platform_sequences:
     cmd:
     - uv run python ./scripts/platform_train_loop/split_selected_sequences.py --dir-platform-selected-sequences
@@ -455,9 +455,9 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences/
       hash: md5
-      md5: 961ad9763f7d21524af120ca6a5876a7.dir
-      size: 478430836
-      nfiles: 4947
+      md5: 41f12ac46242b9580dd08082c0afb5ea.dir
+      size: 478432851
+      nfiles: 4973
     - path: ./scripts/platform_train_loop/split_selected_sequences.py
       hash: md5
       md5: 7a24fa5ed1bc9266af14bcda3704aaf9
@@ -465,9 +465,9 @@ stages:
     outs:
     - path: ./data/interim/pyronear-platform/sequences-data-split/
       hash: md5
-      md5: 05af3b28a809a3f31359ffb4a2802083.dir
-      size: 478430836
-      nfiles: 4947
+      md5: 3fbe65fa432285c118000ea8241650b6.dir
+      size: 478432851
+      nfiles: 4973
   make_ultralytics_dataset_from_platform_sequences:
     cmd:
     - uv run python ./scripts/platform_train_loop/make_ultralytics_dataset.py --dir-save
@@ -476,13 +476,13 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-data-split/
       hash: md5
-      md5: 08ca4cc10ce2314c5a9efaec89eb8942.dir
-      size: 478430592
-      nfiles: 4944
+      md5: 3fbe65fa432285c118000ea8241650b6.dir
+      size: 478432851
+      nfiles: 4973
     - path: ./scripts/platform_train_loop/make_ultralytics_dataset.py
       hash: md5
-      md5: 6c83dd7f08415e1ac4bf83b0cfaad529
-      size: 11218
+      md5: 1fbcf5b7feb0335e1932bb42c0a0b42c
+      size: 11237
     outs:
     - path: ./data/interim/pyronear-platform/sequences-ultralytics/
       hash: md5
@@ -498,14 +498,14 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-data-split/
       hash: md5
-      md5: 05af3b28a809a3f31359ffb4a2802083.dir
-      size: 478430836
-      nfiles: 4947
+      md5: 3fbe65fa432285c118000ea8241650b6.dir
+      size: 478432851
+      nfiles: 4973
     - path: ./data/raw/pyronear-platform-annotated-sequences/
       hash: md5
-      md5: 002d2b35967962bd0a66b9af60b3a67c.dir
-      size: 1483240963
-      nfiles: 15225
+      md5: 408084518978464702691cf4b43df125.dir
+      size: 1483246773
+      nfiles: 15307
     - path: ./scripts/platform_train_loop/make_temporal_dataset.py
       hash: md5
       md5: a490cfbaccc1e6cafa5327cb3fd1af04
@@ -513,9 +513,9 @@ stages:
     outs:
     - path: ./data/interim/pyronear-platform/sequences-temporal/
       hash: md5
-      md5: c079f94c642a8665864345630eb7dac5.dir
-      size: 363967100
-      nfiles: 7238
+      md5: e619159980b3d7b28f5c9aa3c99d8bee.dir
+      size: 371942567
+      nfiles: 7402
   make_temporal_test_dataset:
     cmd:
     - uv run python ./scripts/make_temporal_test_dataset.py --dir-save ./data/processed/wildfire_temporal_test/
@@ -525,9 +525,9 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-temporal/
       hash: md5
-      md5: afef2864ce5bdd58293985acbd322580.dir
-      size: 362977293
-      nfiles: 7222
+      md5: e619159980b3d7b28f5c9aa3c99d8bee.dir
+      size: 371942567
+      nfiles: 7402
     - path: ./data/raw/wildfire_temporal_test_selection/
       hash: md5
       md5: a7815c74b06bf1b191136a5a65950b74.dir
@@ -551,9 +551,9 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-temporal/
       hash: md5
-      md5: afef2864ce5bdd58293985acbd322580.dir
-      size: 362977293
-      nfiles: 7222
+      md5: e619159980b3d7b28f5c9aa3c99d8bee.dir
+      size: 371942567
+      nfiles: 7402
     - path: ./scripts/make_temporal_train_val_dataset.py
       hash: md5
       md5: 5cfe7141318d08985603df9318594b5b
@@ -561,6 +561,6 @@ stages:
     outs:
     - path: ./data/processed/wildfire_temporal/
       hash: md5
-      md5: d751713988987e9331980363e24189ce.dir
-      size: 0
-      nfiles: 0
+      md5: 96263a82ed6854e8be996e802fd2be77.dir
+      size: 12707739
+      nfiles: 254

--- a/dvc.lock
+++ b/dvc.lock
@@ -434,19 +434,19 @@ stages:
     deps:
     - path: ./data/raw/pyronear-platform-annotated-sequences/
       hash: md5
-      md5: 3fc0e1d726646763d14f20b5c2ed0dac.dir
-      size: 1483240395
-      nfiles: 15217
+      md5: 002d2b35967962bd0a66b9af60b3a67c.dir
+      size: 1483240963
+      nfiles: 15225
     - path: ./scripts/platform_train_loop/select_detections.py
       hash: md5
-      md5: faaf3f3ec211ae4298ac32d0e7a80059
-      size: 14523
+      md5: af4f940bf6cff0f1aa338a214cc59522
+      size: 14560
     outs:
     - path: ./data/interim/pyronear-platform/sequences/
       hash: md5
-      md5: e60c867d5a203de37c461dce8be812a9.dir
-      size: 478430592
-      nfiles: 4944
+      md5: 961ad9763f7d21524af120ca6a5876a7.dir
+      size: 478430836
+      nfiles: 4947
   split_platform_sequences:
     cmd:
     - uv run python ./scripts/platform_train_loop/split_selected_sequences.py --dir-platform-selected-sequences
@@ -455,9 +455,9 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences/
       hash: md5
-      md5: e60c867d5a203de37c461dce8be812a9.dir
-      size: 478430592
-      nfiles: 4944
+      md5: 961ad9763f7d21524af120ca6a5876a7.dir
+      size: 478430836
+      nfiles: 4947
     - path: ./scripts/platform_train_loop/split_selected_sequences.py
       hash: md5
       md5: 7a24fa5ed1bc9266af14bcda3704aaf9
@@ -465,9 +465,9 @@ stages:
     outs:
     - path: ./data/interim/pyronear-platform/sequences-data-split/
       hash: md5
-      md5: 08ca4cc10ce2314c5a9efaec89eb8942.dir
-      size: 478430592
-      nfiles: 4944
+      md5: 05af3b28a809a3f31359ffb4a2802083.dir
+      size: 478430836
+      nfiles: 4947
   make_ultralytics_dataset_from_platform_sequences:
     cmd:
     - uv run python ./scripts/platform_train_loop/make_ultralytics_dataset.py --dir-save
@@ -498,14 +498,14 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-data-split/
       hash: md5
-      md5: 08ca4cc10ce2314c5a9efaec89eb8942.dir
-      size: 478430592
-      nfiles: 4944
+      md5: 05af3b28a809a3f31359ffb4a2802083.dir
+      size: 478430836
+      nfiles: 4947
     - path: ./data/raw/pyronear-platform-annotated-sequences/
       hash: md5
-      md5: 3fc0e1d726646763d14f20b5c2ed0dac.dir
-      size: 1483240395
-      nfiles: 15217
+      md5: 002d2b35967962bd0a66b9af60b3a67c.dir
+      size: 1483240963
+      nfiles: 15225
     - path: ./scripts/platform_train_loop/make_temporal_dataset.py
       hash: md5
       md5: a490cfbaccc1e6cafa5327cb3fd1af04
@@ -513,9 +513,9 @@ stages:
     outs:
     - path: ./data/interim/pyronear-platform/sequences-temporal/
       hash: md5
-      md5: afef2864ce5bdd58293985acbd322580.dir
-      size: 362977293
-      nfiles: 7222
+      md5: c079f94c642a8665864345630eb7dac5.dir
+      size: 363967100
+      nfiles: 7238
   make_temporal_test_dataset:
     cmd:
     - uv run python ./scripts/make_temporal_test_dataset.py --dir-save ./data/processed/wildfire_temporal_test/

--- a/dvc.lock
+++ b/dvc.lock
@@ -434,9 +434,9 @@ stages:
     deps:
     - path: ./data/raw/pyronear-platform-annotated-sequences/
       hash: md5
-      md5: 408084518978464702691cf4b43df125.dir
-      size: 1483246773
-      nfiles: 15307
+      md5: e9cb84ab57ea8159a2c7106565c5c68f.dir
+      size: 1483247254
+      nfiles: 15313
     - path: ./scripts/platform_train_loop/select_detections.py
       hash: md5
       md5: af4f940bf6cff0f1aa338a214cc59522
@@ -444,9 +444,9 @@ stages:
     outs:
     - path: ./data/interim/pyronear-platform/sequences/
       hash: md5
-      md5: 41f12ac46242b9580dd08082c0afb5ea.dir
-      size: 478432851
-      nfiles: 4973
+      md5: 4169d7343628c22e83c663a8a6063d42.dir
+      size: 478432930
+      nfiles: 4974
   split_platform_sequences:
     cmd:
     - uv run python ./scripts/platform_train_loop/split_selected_sequences.py --dir-platform-selected-sequences
@@ -455,9 +455,9 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences/
       hash: md5
-      md5: 41f12ac46242b9580dd08082c0afb5ea.dir
-      size: 478432851
-      nfiles: 4973
+      md5: 4169d7343628c22e83c663a8a6063d42.dir
+      size: 478432930
+      nfiles: 4974
     - path: ./scripts/platform_train_loop/split_selected_sequences.py
       hash: md5
       md5: 7a24fa5ed1bc9266af14bcda3704aaf9
@@ -465,9 +465,9 @@ stages:
     outs:
     - path: ./data/interim/pyronear-platform/sequences-data-split/
       hash: md5
-      md5: 3fbe65fa432285c118000ea8241650b6.dir
-      size: 478432851
-      nfiles: 4973
+      md5: 41227249e1f7dc7d5c4168a2e6eab3a3.dir
+      size: 478432930
+      nfiles: 4974
   make_ultralytics_dataset_from_platform_sequences:
     cmd:
     - uv run python ./scripts/platform_train_loop/make_ultralytics_dataset.py --dir-save
@@ -476,13 +476,13 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-data-split/
       hash: md5
-      md5: 3fbe65fa432285c118000ea8241650b6.dir
-      size: 478432851
-      nfiles: 4973
+      md5: 41227249e1f7dc7d5c4168a2e6eab3a3.dir
+      size: 478432930
+      nfiles: 4974
     - path: ./scripts/platform_train_loop/make_ultralytics_dataset.py
       hash: md5
-      md5: 1fbcf5b7feb0335e1932bb42c0a0b42c
-      size: 11237
+      md5: 162d6707ee5289743f6b25825f869858
+      size: 11340
     outs:
     - path: ./data/interim/pyronear-platform/sequences-ultralytics/
       hash: md5
@@ -498,14 +498,14 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-data-split/
       hash: md5
-      md5: 3fbe65fa432285c118000ea8241650b6.dir
-      size: 478432851
-      nfiles: 4973
+      md5: 41227249e1f7dc7d5c4168a2e6eab3a3.dir
+      size: 478432930
+      nfiles: 4974
     - path: ./data/raw/pyronear-platform-annotated-sequences/
       hash: md5
-      md5: 408084518978464702691cf4b43df125.dir
-      size: 1483246773
-      nfiles: 15307
+      md5: e9cb84ab57ea8159a2c7106565c5c68f.dir
+      size: 1483247254
+      nfiles: 15313
     - path: ./scripts/platform_train_loop/make_temporal_dataset.py
       hash: md5
       md5: a490cfbaccc1e6cafa5327cb3fd1af04
@@ -513,9 +513,9 @@ stages:
     outs:
     - path: ./data/interim/pyronear-platform/sequences-temporal/
       hash: md5
-      md5: e619159980b3d7b28f5c9aa3c99d8bee.dir
-      size: 371942567
-      nfiles: 7402
+      md5: 9f205c9c1a792006fb3c446cacbccd28.dir
+      size: 372616592
+      nfiles: 7414
   make_temporal_test_dataset:
     cmd:
     - uv run python ./scripts/make_temporal_test_dataset.py --dir-save ./data/processed/wildfire_temporal_test/
@@ -525,9 +525,9 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-temporal/
       hash: md5
-      md5: e619159980b3d7b28f5c9aa3c99d8bee.dir
-      size: 371942567
-      nfiles: 7402
+      md5: 9f205c9c1a792006fb3c446cacbccd28.dir
+      size: 372616592
+      nfiles: 7414
     - path: ./data/raw/wildfire_temporal_test_selection/
       hash: md5
       md5: a7815c74b06bf1b191136a5a65950b74.dir
@@ -551,9 +551,9 @@ stages:
     deps:
     - path: ./data/interim/pyronear-platform/sequences-temporal/
       hash: md5
-      md5: e619159980b3d7b28f5c9aa3c99d8bee.dir
-      size: 371942567
-      nfiles: 7402
+      md5: 9f205c9c1a792006fb3c446cacbccd28.dir
+      size: 372616592
+      nfiles: 7414
     - path: ./scripts/make_temporal_train_val_dataset.py
       hash: md5
       md5: 5cfe7141318d08985603df9318594b5b
@@ -561,6 +561,6 @@ stages:
     outs:
     - path: ./data/processed/wildfire_temporal/
       hash: md5
-      md5: 96263a82ed6854e8be996e802fd2be77.dir
-      size: 12707739
-      nfiles: 254
+      md5: 99f3bc1ba4aeb023a7cbe072b1bba7f4.dir
+      size: 14000323
+      nfiles: 274

--- a/scripts/platform_train_loop/make_ultralytics_dataset.py
+++ b/scripts/platform_train_loop/make_ultralytics_dataset.py
@@ -191,7 +191,8 @@ def make_ultralytics_format(
     Returns:
         dict: A dictionary containing the formatted dataset with images and labels.
     """
-    filepaths_labels = list(dir_sequence.glob("**/*.txt"))
+    # TODO: use the labels_ground_truth instead of the labels_predictions once everything is annotated
+    filepaths_labels = list(dir_sequence.glob("**/labels_predictions/*.txt"))
     filepaths_images = [
         fp for fp in dir_sequence.glob("**/*.jpg") if "images" in str(fp)
     ]

--- a/scripts/platform_train_loop/select_detections.py
+++ b/scripts/platform_train_loop/select_detections.py
@@ -318,7 +318,7 @@ def copy_over(
             dst=filepath_destination_label_prediction,
         )
 
-        if filepath_destination_label_ground_truth.exists():
+        if filepath_source_label_ground_truth.exists():
             shutil.copy(
                 src=filepath_source_label_ground_truth,
                 dst=filepath_destination_label_ground_truth,
@@ -348,7 +348,7 @@ if __name__ == "__main__":
         logger.info(f"Selecting the false positives from {dirs_fp}")
         for dir_fp in dirs_fp:
             dirs_sequences_fp = find_sequence_folders(dir_fp)
-            print(
+            logger.info(
                 f"Found {len(dirs_sequences_fp)} false positive sequences in {dir_fp}"
             )
             for dir_sequence_fp in dirs_sequences_fp:
@@ -366,7 +366,9 @@ if __name__ == "__main__":
         logger.info(f"Selecting the true positives from {dirs_tp}")
         for dir_tp in dirs_tp:
             dirs_sequences_tp = find_sequence_folders(dir_tp)
-            print(f"Found {len(dirs_sequences_tp)} true positive sequences in {dir_tp}")
+            logger.info(
+                f"Found {len(dirs_sequences_tp)} true positive sequences in {dir_tp}"
+            )
             for dir_sequence_tp in dirs_sequences_tp:
                 records = select_best_true_positives(
                     dir_sequence_tp,


### PR DESCRIPTION
## Description

End to end POC that we can easily annotate sequences (using LabelStudio) in my case and commit the dvc data to regenerate the temporal dataset end to end.